### PR TITLE
feat: Chunked market history fetch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,7 @@ task scrapeMarketHistory(type: JavaExec) {
 	args "scrape-market-history"
 	environment envProperties
 	environment "ESI_RATE_LIMIT_PER_S", "5"
+	environment "ESI_MARKET_HISTORY_CHUNK_SIZE", "1000"
 	classpath = sourceSets.main.runtimeClasspath
 	mainClass = mainClassName
 }

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ task scrapeMarketHistory(type: JavaExec) {
 	args "scrape-market-history"
 	environment envProperties
 	environment "ESI_RATE_LIMIT_PER_S", "5"
-	environment "ESI_MARKET_HISTORY_CHUNK_SIZE", "1000"
+	environment "ESI_MARKET_HISTORY_CHUNK_SIZE", "10000"
 	classpath = sourceSets.main.runtimeClasspath
 	mainClass = mainClassName
 }

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/ActiveOrdersRegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/ActiveOrdersRegionTypeSource.java
@@ -4,8 +4,8 @@ import com.autonomouslogic.everef.esi.MarketEsi;
 import com.autonomouslogic.everef.model.MarketHistoryEntry;
 import com.autonomouslogic.everef.model.RegionTypePair;
 import io.reactivex.rxjava3.core.Flowable;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
@@ -30,7 +30,7 @@ class ActiveOrdersRegionTypeSource implements RegionTypeSource {
 	}
 
 	@Override
-	public Flowable<RegionTypePair> sourcePairs(List<RegionTypePair> currentPairs) {
+	public Flowable<RegionTypePair> sourcePairs(Collection<RegionTypePair> currentPairs) {
 		return Flowable.fromIterable(regions).flatMap(regionId -> marketEsi
 				.getActiveMarketOrderTypes(regionId)
 				.map(typeId -> new RegionTypePair(regionId, typeId)));

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/ActiveOrdersRegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/ActiveOrdersRegionTypeSource.java
@@ -1,7 +1,8 @@
 package com.autonomouslogic.everef.cli.markethistory;
 
 import com.autonomouslogic.everef.esi.MarketEsi;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.autonomouslogic.everef.model.MarketHistoryEntry;
+import com.autonomouslogic.everef.model.RegionTypePair;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +25,7 @@ class ActiveOrdersRegionTypeSource implements RegionTypeSource {
 	protected ActiveOrdersRegionTypeSource() {}
 
 	@Override
-	public void addHistory(JsonNode entry) {
+	public void addHistory(MarketHistoryEntry entry) {
 		regions.add(RegionTypePair.fromHistory(entry).getRegionId());
 	}
 

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/CompoundRegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/CompoundRegionTypeSource.java
@@ -1,7 +1,8 @@
 package com.autonomouslogic.everef.cli.markethistory;
 
 import com.autonomouslogic.commons.ListUtil;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.autonomouslogic.everef.model.MarketHistoryEntry;
+import com.autonomouslogic.everef.model.RegionTypePair;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,7 +58,7 @@ class CompoundRegionTypeSource implements RegionTypeSource {
 	}
 
 	@Override
-	public void addHistory(JsonNode entry) {
+	public void addHistory(MarketHistoryEntry entry) {
 		for (RegionTypeSource source : sources) {
 			source.addHistory(entry);
 		}

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/HistoryRegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/HistoryRegionTypeSource.java
@@ -1,11 +1,12 @@
 package com.autonomouslogic.everef.cli.markethistory;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.autonomouslogic.everef.model.MarketHistoryEntry;
+import com.autonomouslogic.everef.model.RegionTypeMarketCap;
+import com.autonomouslogic.everef.model.RegionTypePair;
+import com.autonomouslogic.everef.util.MarketCapCalc;
+import com.google.common.collect.Ordering;
 import io.reactivex.rxjava3.core.Flowable;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import lombok.extern.log4j.Log4j2;
 
@@ -14,18 +15,28 @@ import lombok.extern.log4j.Log4j2;
  */
 @Log4j2
 class HistoryRegionTypeSource implements RegionTypeSource {
-	private final Set<RegionTypePair> pairs = Collections.newSetFromMap(new ConcurrentHashMap<>());
+	private static final Ordering<RegionTypeMarketCap> ORDERING =
+			Ordering.natural().onResultOf(RegionTypeMarketCap::getCap).reverse();
+
+	@Inject
+	protected MarketCapCalc marketCapCalc;
 
 	@Inject
 	protected HistoryRegionTypeSource() {}
 
 	@Override
-	public void addHistory(JsonNode entry) {
-		pairs.add(RegionTypePair.fromHistory(entry));
+	public void addHistory(MarketHistoryEntry entry) {
+		marketCapCalc.add(entry);
 	}
 
 	@Override
 	public Flowable<RegionTypePair> sourcePairs(List<RegionTypePair> currentPairs) {
+		var sortedCaps = marketCapCalc.getRegionTypeMarketCaps().stream()
+				.sorted(ORDERING)
+				.toList();
+		var pairs = sortedCaps.stream()
+				.map(cap -> new RegionTypePair(cap.getRegionId(), cap.getTypeId()))
+				.toList();
 		return Flowable.fromIterable(pairs);
 	}
 }

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/HistoryRegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/HistoryRegionTypeSource.java
@@ -6,7 +6,7 @@ import com.autonomouslogic.everef.model.RegionTypePair;
 import com.autonomouslogic.everef.util.MarketCapCalc;
 import com.google.common.collect.Ordering;
 import io.reactivex.rxjava3.core.Flowable;
-import java.util.List;
+import java.util.Collection;
 import javax.inject.Inject;
 import lombok.extern.log4j.Log4j2;
 
@@ -30,10 +30,11 @@ class HistoryRegionTypeSource implements RegionTypeSource {
 	}
 
 	@Override
-	public Flowable<RegionTypePair> sourcePairs(List<RegionTypePair> currentPairs) {
+	public Flowable<RegionTypePair> sourcePairs(Collection<RegionTypePair> currentPairs) {
 		var sortedCaps = marketCapCalc.getRegionTypeMarketCaps().stream()
 				.sorted(ORDERING)
 				.toList();
+		sortedCaps.stream().limit(20).forEach(cap -> log.trace("Top cap: {}", cap));
 		var pairs = sortedCaps.stream()
 				.map(cap -> new RegionTypePair(cap.getRegionId(), cap.getTypeId()))
 				.toList();

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryFetcher.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryFetcher.java
@@ -2,6 +2,7 @@ package com.autonomouslogic.everef.cli.markethistory;
 
 import com.autonomouslogic.everef.esi.EsiHelper;
 import com.autonomouslogic.everef.esi.EsiUrl;
+import com.autonomouslogic.everef.model.RegionTypePair;
 import com.autonomouslogic.everef.util.OkHttpHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/RegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/RegionTypeSource.java
@@ -3,7 +3,7 @@ package com.autonomouslogic.everef.cli.markethistory;
 import com.autonomouslogic.everef.model.MarketHistoryEntry;
 import com.autonomouslogic.everef.model.RegionTypePair;
 import io.reactivex.rxjava3.core.Flowable;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * A specific source for region-type pairs to be searched for market history.
@@ -11,5 +11,5 @@ import java.util.List;
 interface RegionTypeSource {
 	default void addHistory(MarketHistoryEntry entry) {}
 
-	Flowable<RegionTypePair> sourcePairs(List<RegionTypePair> currentPairs);
+	Flowable<RegionTypePair> sourcePairs(Collection<RegionTypePair> currentPairs);
 }

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/RegionTypeSource.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/RegionTypeSource.java
@@ -1,6 +1,7 @@
 package com.autonomouslogic.everef.cli.markethistory;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.autonomouslogic.everef.model.MarketHistoryEntry;
+import com.autonomouslogic.everef.model.RegionTypePair;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
 
@@ -8,7 +9,7 @@ import java.util.List;
  * A specific source for region-type pairs to be searched for market history.
  */
 interface RegionTypeSource {
-	default void addHistory(JsonNode entry) {}
+	default void addHistory(MarketHistoryEntry entry) {}
 
 	Flowable<RegionTypePair> sourcePairs(List<RegionTypePair> currentPairs);
 }

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/ScrapeMarketHistory.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/ScrapeMarketHistory.java
@@ -25,7 +25,6 @@ import java.io.FileOutputStream;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/ScrapeMarketHistory.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/ScrapeMarketHistory.java
@@ -196,7 +196,6 @@ public class ScrapeMarketHistory implements Command {
 		return Flowable.defer(() -> {
 			log.info("Sourcing pairs");
 			return regionTypeSource.sourcePairs().toList().flatMapPublisher(pairs -> {
-				Collections.shuffle(pairs);
 				log.info("Sourced {} pairs", pairs.size());
 				progressReporter = new ProgressReporter(getName(), pairs.size(), Duration.ofMinutes(1));
 				progressReporter.start();

--- a/src/main/java/com/autonomouslogic/everef/config/Configs.java
+++ b/src/main/java/com/autonomouslogic/everef/config/Configs.java
@@ -220,6 +220,15 @@ public class Configs {
 			.build();
 
 	/**
+	 * Chunk size for the market history scrape.
+	 */
+	public static final Config<Integer> ESI_MARKET_HISTORY_CHUNK_SIZE = Config.<Integer>builder()
+			.name("ESI_MARKET_HISTORY_CHUNK_SIZE")
+			.type(Integer.class)
+			.defaultValue(Integer.MAX_VALUE)
+			.build();
+
+	/**
 	 * Concurrency for the market history scrape.
 	 */
 	public static final Config<Integer> ESI_MARKET_HISTORY_CONCURRENCY = Config.<Integer>builder()

--- a/src/main/java/com/autonomouslogic/everef/model/RegionTypeMarketCap.java
+++ b/src/main/java/com/autonomouslogic/everef/model/RegionTypeMarketCap.java
@@ -1,0 +1,15 @@
+package com.autonomouslogic.everef.model;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder(toBuilder = true)
+@Jacksonized
+public class RegionTypeMarketCap {
+	int regionId;
+	int typeId;
+	BigDecimal cap;
+}

--- a/src/main/java/com/autonomouslogic/everef/model/RegionTypePair.java
+++ b/src/main/java/com/autonomouslogic/everef/model/RegionTypePair.java
@@ -1,11 +1,10 @@
-package com.autonomouslogic.everef.cli.markethistory;
+package com.autonomouslogic.everef.model;
 
-import com.autonomouslogic.everef.model.MarketHistoryEntry;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Value;
 
 @Value
-class RegionTypePair {
+public class RegionTypePair {
 	int regionId;
 	int typeId;
 

--- a/src/main/java/com/autonomouslogic/everef/mvstore/MVStoreUtil.java
+++ b/src/main/java/com/autonomouslogic/everef/mvstore/MVStoreUtil.java
@@ -39,6 +39,7 @@ public class MVStoreUtil {
 		log.debug("MVStore opened at " + file.getAbsolutePath());
 		var builder = new MVStore.Builder()
 				.fileName(file.getAbsolutePath())
+				.autoCompactFillRate(0)
 				.compress()
 				.cacheSize(cacheSize);
 		var store = builder.open();

--- a/src/main/java/com/autonomouslogic/everef/util/MarketCapCalc.java
+++ b/src/main/java/com/autonomouslogic/everef/util/MarketCapCalc.java
@@ -1,0 +1,43 @@
+package com.autonomouslogic.everef.util;
+
+import com.autonomouslogic.everef.model.MarketHistoryEntry;
+import com.autonomouslogic.everef.model.RegionTypeMarketCap;
+import com.autonomouslogic.everef.model.RegionTypePair;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+
+/**
+ * Calculates the market capitalisation for each type.
+ */
+public class MarketCapCalc {
+	private final Map<RegionTypePair, BigDecimal> caps = new HashMap<>();
+
+	@Inject
+	protected MarketCapCalc() {}
+
+	public synchronized void add(MarketHistoryEntry entry) {
+		var key = RegionTypePair.fromHistory(entry);
+		var cap = caps.get(key);
+		if (cap == null) {
+			cap = BigDecimal.ZERO;
+		}
+		var price = entry.getAverage();
+		var volume = BigDecimal.valueOf(entry.getVolume());
+		var entryCap = price.multiply(volume);
+		cap = cap.add(entryCap);
+		caps.put(key, cap);
+	}
+
+	public List<RegionTypeMarketCap> getRegionTypeMarketCaps() {
+		return caps.entrySet().stream()
+				.map(entry -> RegionTypeMarketCap.builder()
+						.regionId(entry.getKey().getRegionId())
+						.typeId(entry.getKey().getTypeId())
+						.cap(entry.getValue())
+						.build())
+				.toList();
+	}
+}


### PR DESCRIPTION
Chunks up the (region, type) pairs and updates the archive files for every chunk.

Relates to #7, extends #124.