### PR TITLE
fix: Non-bonus role bonuses

### DIFF
--- a/ui/components/dogma/UnitValue.vue
+++ b/ui/components/dogma/UnitValue.vue
@@ -2,8 +2,8 @@
 import refdataApi from "~/refdata";
 
 const props = defineProps<{
-	value: string | number | undefined,
-	unitId: number | undefined
+	value: string | number,
+	unitId: number
 }>();
 
 const {locale} = useI18n();

--- a/ui/components/types/traits/TraitGroup.vue
+++ b/ui/components/types/traits/TraitGroup.vue
@@ -19,7 +19,10 @@ const hasBonuses: boolean = props.bonuses !== undefined && Object.keys(props.bon
 		<h3>{{ props.title }}</h3>
 		<ul>
 			<li v-for="(trait, i) in props.bonuses" :key="i">
-				<UnitValue :value="trait.bonus" :unit-id="trait.unitId" /> <LinkParser :content="trait.bonusText[locale]"/>
+				<template v-if="trait.bonus !== undefined && trait.unitId !== undefined">
+					<UnitValue :value="trait.bonus" :unit-id="trait.unitId" />&nbsp;
+				</template>
+				<LinkParser :content="trait.bonusText[locale]"/>
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
This was an issue on [type 22440](https://ref-data.everef.net/types/22440) due to some entries on `traits/role_bonuses` not containing `bonus` or `unit_id` fields.