### PR TITLE
chore(deps): Updated to Bouncy Castle for JVM 1.8 [skip release]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,7 @@ dependencies {
 	implementation "javax.annotation:javax.annotation-api:1.3.2"
 	implementation "org.openapitools:jackson-databind-nullable:0.2.6"
 	implementation "org.apache.commons:commons-rng-simple:1.5"
-
-	// Not updated since 2021, change to org.bouncycastle:bcprov-jdk18on:1.77 when Kotlin supports JVM 21 or Kotlin is removed.
-	implementation "org.bouncycastle:bcprov-jdk15on:1.70"
+	implementation "org.bouncycastle:bcprov-jdk18on:1.77"
 
 	implementation "org.jooq:jooq:3.18.7"
 	implementation "org.flywaydb:flyway-core:9.22.3"


### PR DESCRIPTION
The Bouncy Castle dependency wasn't for JVM 18, but JVM 1.8.

https://www.bouncycastle.org/latest_releases.html