### PR TITLE
fix(deps): Downgraded AWS to 2.29.50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,8 @@ dependencies {
 		exclude group: "org.graalvm.tools"
 		exclude group: "com.vladsch.flexmark"
 	}
-	implementation "software.amazon.awssdk:s3:2.30.11"
-	implementation "software.amazon.awssdk:dynamodb:2.30.11"
+	implementation "software.amazon.awssdk:s3:2.29.50"
+	implementation "software.amazon.awssdk:dynamodb:2.29.50"
 	implementation "com.autonomouslogic.dynamomapper:dynamo-mapper:2.1.17"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.18.2"
 	implementation "com.fasterxml.jackson.core:jackson-core:2.18.2"

--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,11 @@
       "io.swagger.core.v3.swagger-gradle-plugin"
     ],
     "allowedVersions": ">2.2.27"
+  }, {
+    "matchPackageNames": [
+      "software.amazon.awssdk:s3",
+      "software.amazon.awssdk:dynamodb"
+    ],
+    "allowedVersions": ">2.30.11"
   }]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,12 @@
     ],
     "allowedVersions": ">2.2.27"
   }, {
+    "groupName": "aws",
     "matchPackageNames": [
       "software.amazon.awssdk:s3",
       "software.amazon.awssdk:dynamodb"
     ],
-    "allowedVersions": ">2.30.11"
+    "allowedVersions": ">2.30.11",
+    "automerge": false
   }]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,19 +11,15 @@
         "org.flywaydb.flyway",
         "org.flywaydb:flyway-core"
       ]
-    }, {
-    "groupName": "swagger-gradle-plugin",
-    "matchPackageNames": [
-      "io.swagger.core.v3.swagger-gradle-plugin"
-    ],
-    "allowedVersions": ">2.2.27"
-  }, {
-    "groupName": "aws",
-    "matchPackageNames": [
-      "software.amazon.awssdk:s3",
-      "software.amazon.awssdk:dynamodb"
-    ],
-    "allowedVersions": ">2.30.11",
-    "automerge": false
-  }]
+    },
+    {
+      "groupName": "aws",
+      "matchPackageNames": [
+        "software.amazon.awssdk:s3",
+        "software.amazon.awssdk:dynamodb"
+      ],
+      "allowedVersions": ">2.30.11",
+      "automerge": false
+    }
+  ]
 }

--- a/renovate.md
+++ b/renovate.md
@@ -2,4 +2,4 @@
 
 The following packages are locked:
 
-* `ubuntu` and and `eclipse-temurin` fixed at `20.04`/`focal` because using  `22.04`/`jammy` requires a newer version of Docker - [reference](https://stackoverflow.com/questions/72841549/container-fails-to-start-insufficient-memory-for-the-java-runtime-environment-t)
+* `aws`: https://github.com/autonomouslogic/eve-ref/pull/727


### PR DESCRIPTION
Something in the latest version doesn't work with Backblaze. Downgrading.

Possibly new checksum algorithm in https://github.com/aws/aws-sdk-java-v2/releases/tag/2.30.0