### PR TITLE
fix(jobs): Out of memory in the import market history job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -372,7 +372,7 @@ task importMarketHistory(type: JavaExec) {
 	args "import-market-history"
 	environment envProperties
 	environment "LOG_LEVEL", "debug"
-	environment "DATABASE_URL", "jdbc:h2:file:${buildDir}/everef-data;AUTO_SERVER=true"
+//	environment "DATABASE_URL", "jdbc:h2:file:${buildDir}/everef-data;AUTO_SERVER=true"
 	environment "IMPORT_MARKET_HISTORY_MIN_DATE", LocalDate.now().minusDays(7).toString();
 
 	classpath = sourceSets.main.runtimeClasspath

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryLoader.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryLoader.java
@@ -6,7 +6,6 @@ import com.autonomouslogic.everef.model.MarketHistoryEntry;
 import com.autonomouslogic.everef.url.DataUrl;
 import com.autonomouslogic.everef.util.CompressUtil;
 import com.autonomouslogic.everef.util.TempFiles;
-import com.autonomouslogic.everef.util.VirtualThreads;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
@@ -52,15 +51,15 @@ public class MarketHistoryLoader {
 				.withColumnReordering(true);
 	}
 
+	@Deprecated
 	public Flowable<Pair<LocalDate, List<JsonNode>>> loadDailyFile(DataUrl url, LocalDate date) {
-		log.debug("Load daily file for {}", date);
 		return downloadFile(url).flatMapPublisher(file -> {
 			file.deleteOnExit();
 			return parseDailyFile(file, date).doFinally(() -> file.delete());
 		});
 	}
 
-	private Single<File> downloadFile(DataUrl url) {
+	public Single<File> downloadFile(DataUrl url) {
 		return Single.defer(() -> {
 			var file = tempFiles
 					.tempFile("market-history", "-" + FilenameUtils.getName(url.getPath()))
@@ -84,7 +83,7 @@ public class MarketHistoryLoader {
 		});
 	}
 
-	private Flowable<Pair<LocalDate, List<JsonNode>>> parseDailyFile(File file, LocalDate date) {
+	public Flowable<Pair<LocalDate, List<JsonNode>>> parseDailyFile(File file, LocalDate date) {
 		return Flowable.defer(() -> {
 			log.trace("Reading market history file: {}", file);
 			List<JsonNode> list;

--- a/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryLoader.java
+++ b/src/main/java/com/autonomouslogic/everef/cli/markethistory/MarketHistoryLoader.java
@@ -53,6 +53,7 @@ public class MarketHistoryLoader {
 	}
 
 	public Flowable<Pair<LocalDate, List<JsonNode>>> loadDailyFile(DataUrl url, LocalDate date) {
+		log.debug("Load daily file for {}", date);
 		return downloadFile(url).flatMapPublisher(file -> {
 			file.deleteOnExit();
 			return parseDailyFile(file, date).doFinally(() -> file.delete());
@@ -84,7 +85,7 @@ public class MarketHistoryLoader {
 	}
 
 	private Flowable<Pair<LocalDate, List<JsonNode>>> parseDailyFile(File file, LocalDate date) {
-		return Flowable.defer(() -> VirtualThreads.offload(() -> {
+		return Flowable.defer(() -> {
 			log.trace("Reading market history file: {}", file);
 			List<JsonNode> list;
 			try (var in = CompressUtil.uncompress(file)) {
@@ -92,7 +93,7 @@ public class MarketHistoryLoader {
 			}
 			log.trace("Read {} entries from {}", list.size(), file);
 			return Flowable.just(Pair.of(date, list));
-		}));
+		});
 	}
 
 	@NotNull

--- a/src/main/java/com/autonomouslogic/everef/db/DbAdapter.java
+++ b/src/main/java/com/autonomouslogic/everef/db/DbAdapter.java
@@ -29,9 +29,7 @@ public class DbAdapter {
 
 	public <R extends UpdatableRecord<R>> void insert(DSLContext ctx, Table<R> table, List<R> records) {
 		var stmt = ctx.insertInto(table).columns(table.fields());
-		for (var record : records) {
-			stmt = stmt.values(record);
-		}
+		stmt = stmt.valuesOfRecords(records);
 		stmt.onDuplicateKeyIgnore().execute();
 		log.debug("Inserted {} records into {}", records.size(), table.getName());
 	}


### PR DESCRIPTION
The market history import runs out of memory during import when using 2 GB of memory. This used to be enough before the Rx refactor. It looks like it's loading and caching parsed files in memory before being ready to insert them. 

The flow needs to be changed so files are downloaded concurrently, but aren't read until they're ready to be inserted.