### PR TITLE
fix: Revert MVStore to default settings

### DIFF
--- a/src/main/java/com/autonomouslogic/everef/mvstore/MVStoreUtil.java
+++ b/src/main/java/com/autonomouslogic/everef/mvstore/MVStoreUtil.java
@@ -44,7 +44,6 @@ public class MVStoreUtil {
 				.compress()
 				.autoCompactFillRate(50);
 		var store = builder.open();
-		store.setVersionsToKeep(0);
 		return store;
 	}
 


### PR DESCRIPTION
Revert MVStore to default retention settings following discussion in https://github.com/h2database/h2database/issues/4383